### PR TITLE
fix: Adjusting the CI workflow and Dockerfile for JDK 24 and port change

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -11,17 +11,26 @@ permissions:
 jobs:
   CI:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '24'
+
+      - name: Build JAR with Maven
+        run: mvn -B clean package -DskipTests
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
 
       - name: Install go-semantic-release
         run: go install github.com/go-semantic-release/semantic-release/v2/cmd/semantic-release@latest
@@ -43,7 +52,6 @@ jobs:
         with:
           username: ${{ secrets.USERNAME_DOCKER }}
           password: ${{ secrets.PASSWORD_DOCKER }}
-
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM eclipse-temurin:24-jdk
 RUN mkdir /app
 WORKDIR /app
 
-COPY target/painel_administrativo_backend-0.0.1-SNAPSHOT.jar app.jar
+COPY target/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=prod
-ENV SERVER_PORT=8080
+ENV SERVER_PORT=8081
 ENV DATABASE_HOST=
 ENV DATABASE_PORT=3306
 ENV DATABASE_NAME=PAINEL_ADMINISTRATIVO


### PR DESCRIPTION
The CI workflow now sets up JDK 24 and builds the JAR with Maven, and updates Go to version 1.24. The Dockerfile now copies any JAR from the target directory and changes the server port to 8081.